### PR TITLE
fix:bug

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,26 +1,21 @@
 -- stylua: ignore
 local SUPPORTED_KEYS = {
-	{ on = "0"}, { on = "1"}, { on = "2"}, { on = "3"}, { on = "4"},
-	{ on = "5"}, { on = "6"}, { on = "7"}, { on = "8"}, { on = "9"},
-	{ on = "A"}, { on = "B"}, { on = "C"}, { on = "D"}, { on = "E"},
-	{ on = "F"}, { on = "G"}, { on = "H"}, { on = "I"}, { on = "J"},
-	{ on = "K"}, { on = "L"}, { on = "M"}, { on = "N"}, { on = "O"},
-	{ on = "P"}, { on = "Q"}, { on = "R"}, { on = "S"}, { on = "T"},
-	{ on = "U"}, { on = "V"}, { on = "W"}, { on = "X"}, { on = "Y"}, { on = "Z"},
-	{ on = "a"}, { on = "b"}, { on = "c"}, { on = "d"}, { on = "e"},
-	{ on = "f"}, { on = "g"}, { on = "h"}, { on = "i"}, { on = "j"},
-	{ on = "k"}, { on = "l"}, { on = "m"}, { on = "n"}, { on = "o"},
-	{ on = "p"}, { on = "q"}, { on = "r"}, { on = "s"}, { on = "t"},
-	{ on = "u"}, { on = "v"}, { on = "w"}, { on = "x"}, { on = "y"}, { on = "z"},
+	{ on = "p" }, { on = "b" }, { on = "e" }, { on = "t" }, { on = "a" },
+	{ on = "o" }, { on = "i" }, { on = "n" }, { on = "s" }, { on = "r" },
+	{ on = "h" }, { on = "l" }, { on = "d" }, { on = "c" }, { on = "u" },
+	{ on = "m" }, { on = "f" }, { on = "g" }, { on = "w" }, { on = "v" },
+	{ on = "k" }, { on = "j" }, { on = "x" }, { on = "z" }, { on = "y" },
+	{ on = "q" },
 }
 
-local save_bookmark = ya.sync(function(idx)
+local save_bookmark = ya.sync(function()
 	local folder = Folder:by_kind(Folder.CURRENT)
-
+	local under_cursor_file = folder.window[folder.cursor - folder.offset + 1]
 	state.bookmarks = state.bookmarks or {}
 	state.bookmarks[#state.bookmarks + 1] = {
-		on = SUPPORTED_KEYS[idx].on,
-		desc = tostring(folder.cwd),
+		on = SUPPORTED_KEYS[#state.bookmarks + 1].on,
+		cwd = tostring(folder.cwd),
+		desc = tostring(under_cursor_file.url),
 		cursor = folder.cursor,
 	}
 end)
@@ -39,10 +34,7 @@ return {
 		end
 
 		if action == "save" then
-			local key = ya.which { cands = SUPPORTED_KEYS, silent = true }
-			if key then
-				save_bookmark(key)
-			end
+			save_bookmark()
 			return
 		end
 
@@ -57,7 +49,7 @@ return {
 		end
 
 		if action == "jump" then
-			ya.manager_emit("cd", { bookmarks[selected].desc })
+			ya.manager_emit("cd", { bookmarks[selected].cwd })
 			ya.manager_emit("arrow", { -99999999 })
 			ya.manager_emit("arrow", { bookmarks[selected].cursor })
 		elseif action == "delete" then


### PR DESCRIPTION
1. Fix that after adding multiple bookmarks, the prompt key is the same when selecting Jump

2. Optimize the prompt for the key to the specific file url, so that the label of the same directory cannot be distinguished

3. Fix adding a bookmark that is still stuck in a thread without exiting