### PR TITLE
Add option to disable using hovered directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ require("bookmarks"):setup({
 	last_directory = { enable = false, persist = false },
 	persist = "none",
 	desc_format = "full",
-	bookmark_file_pick_mode = "hover",
+	file_pick_mode = "hover",
 	notify = {
 		enable = false,
 		timeout = 1,
@@ -136,7 +136,7 @@ There are two possible values for this option:
 | `full`   | The default, it shows the full path of the bookmark, i.e., the parent folder + the hovered file |
 | `parent` | Only shows the parent folder of the bookmark                                                    |
 
-### `bookmark_file_pick_mode`
+### `file_pick_mode`
 
 The mode for choosing which directory to bookmark.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ require("bookmarks"):setup({
 	last_directory = { enable = false, persist = false },
 	persist = "none",
 	desc_format = "full",
+	bookmark_file_pick_mode = "hover",
 	notify = {
 		enable = false,
 		timeout = 1,
@@ -134,6 +135,17 @@ There are two possible values for this option:
 | -------- | ----------------------------------------------------------------------------------------------- |
 | `full`   | The default, it shows the full path of the bookmark, i.e., the parent folder + the hovered file |
 | `parent` | Only shows the parent folder of the bookmark                                                    |
+
+### `bookmark_file_pick_mode`
+
+The mode for choosing which directory to bookmark.
+
+There are two possible values for this option:
+
+| Value    | Description                                                                                     |
+| -------- | ----------------------------------------------------------------------------------------------- |
+| `hover`  | The default, it uses the path of the hovered file for new bookmarks                             |
+| `parent` | Uses the path of the parent folder for new bookmarks                                            |
 
 ### `notify`
 

--- a/init.lua
+++ b/init.lua
@@ -36,7 +36,7 @@ end)
 local _get_bookmark_file = ya.sync(function(state)
 	local folder = cx.active.current
 
-	if state.bookmark_file_pick_mode == "parent" or not folder.hovered then
+	if state.file_pick_mode == "parent" or not folder.hovered then
 		return { url = folder.cwd, is_cwd = true }
 	end
 	return { url = folder.hovered.url, is_cwd = false }
@@ -247,10 +247,10 @@ return {
 			state.desc_format = "full"
 		end
 
-		if args.bookmark_file_pick_mode == "parent" then
-			state.bookmark_file_pick_mode = "parent"
+		if args.file_pick_mode == "parent" then
+			state.file_pick_mode = "parent"
 		else
-			state.bookmark_file_pick_mode = "hover"
+			state.file_pick_mode = "hover"
 		end
 
 		state.notify = {

--- a/init.lua
+++ b/init.lua
@@ -37,14 +37,14 @@ local _get_bookmark_file = ya.sync(function(state)
 	local folder = cx.active.current
 
 	if state.file_pick_mode == "parent" or not folder.hovered then
-		return { url = folder.cwd, is_cwd = true }
+		return { url = folder.cwd, is_parent = true }
 	end
-	return { url = folder.hovered.url, is_cwd = false }
+	return { url = folder.hovered.url, is_parent = false }
 end)
 
 local _generate_description = ya.sync(function(state, file)
 	-- if this is true, we don't have information about the folder, so just return the folder url
-	if file.is_cwd then
+	if file.is_parent then
 		return tostring(file.url)
 	end
 
@@ -106,6 +106,7 @@ local _save_last_directory = ya.sync(function(state, persist)
 			on = "'",
 			desc = _generate_description(file),
 			path = tostring(file.url),
+			is_parent = file.is_parent,
 		}
 	end)
 
@@ -134,6 +135,7 @@ local save_bookmark = ya.sync(function(state, idx)
 		on = SUPPORTED_KEYS[idx].on,
 		desc = _generate_description(file),
 		path = tostring(file.url),
+		is_parent = file.is_parent,
 	}
 
 	if state.persist then
@@ -217,7 +219,11 @@ return {
 		end
 
 		if action == "jump" then
-			ya.manager_emit("reveal", { bookmarks[selected].path })
+			if bookmarks[selected].is_parent then
+				ya.manager_emit("cd", { bookmarks[selected].path })
+			else
+				ya.manager_emit("reveal", { bookmarks[selected].path })
+			end
 		elseif action == "delete" then
 			delete_bookmark(selected)
 		end

--- a/init.lua
+++ b/init.lua
@@ -33,9 +33,10 @@ local _get_real_index = ya.sync(function(state, idx)
 	return nil
 end)
 
-local _get_hovered_file = ya.sync(function()
+local _get_bookmark_file = ya.sync(function(state)
 	local folder = cx.active.current
-	if not folder.hovered then
+
+	if state.bookmark_file_pick_mode == "current" or not folder.hovered then
 		return { url = folder.cwd, is_cwd = true }
 	end
 	return { url = folder.hovered.url, is_cwd = false }
@@ -94,7 +95,7 @@ local _save_last_directory = ya.sync(function(state, persist)
 	end
 
 	ps.sub("cd", function()
-		local file = _get_hovered_file()
+		local file = _get_bookmark_file()
 		state.last_dir = state.curr_dir
 
 		if persist and state.last_dir then
@@ -109,7 +110,7 @@ local _save_last_directory = ya.sync(function(state, persist)
 	end)
 
 	ps.sub("hover", function()
-		local file = _get_hovered_file()
+		local file = _get_bookmark_file()
 		state.curr_dir.desc = _generate_description(file)
 		state.curr_dir.path = tostring(file.url)
 	end)
@@ -120,7 +121,7 @@ end)
 -- ***********************************************
 
 local save_bookmark = ya.sync(function(state, idx)
-	local file = _get_hovered_file()
+	local file = _get_bookmark_file()
 
 	state.bookmarks = state.bookmarks or {}
 
@@ -244,6 +245,12 @@ return {
 			state.desc_format = "parent"
 		else
 			state.desc_format = "full"
+		end
+
+		if args.bookmark_file_pick_mode == "current" then
+			state.bookmark_file_pick_mode = "current"
+		else
+			state.bookmark_file_pick_mode = "hover"
 		end
 
 		state.notify = {

--- a/init.lua
+++ b/init.lua
@@ -36,7 +36,7 @@ end)
 local _get_bookmark_file = ya.sync(function(state)
 	local folder = cx.active.current
 
-	if state.bookmark_file_pick_mode == "current" or not folder.hovered then
+	if state.bookmark_file_pick_mode == "parent" or not folder.hovered then
 		return { url = folder.cwd, is_cwd = true }
 	end
 	return { url = folder.hovered.url, is_cwd = false }
@@ -247,8 +247,8 @@ return {
 			state.desc_format = "full"
 		end
 
-		if args.bookmark_file_pick_mode == "current" then
-			state.bookmark_file_pick_mode = "current"
+		if args.bookmark_file_pick_mode == "parent" then
+			state.bookmark_file_pick_mode = "parent"
 		else
 			state.bookmark_file_pick_mode = "hover"
 		end


### PR DESCRIPTION
Coming from Ranger, I find it very unintuitive that the hovered file is used to create a new bookmark.

I added a new option called `bookmark_file_pick_mode`. With this one can configure to always use the currently open directory when set to `parent`. When set to `hover` the current default behavior ist kept and hovered files are used when available.

I hope this aligns with your vision for the plugin. If you have a better idea for the config option name i would be happy to change.