### PR TITLE
Add custom bookmark description when creating

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ require("bookmarks"):setup({
 	persist = "none",
 	desc_format = "full",
 	file_pick_mode = "hover",
+	custom_desc_input = false,
 	notify = {
 		enable = false,
 		timeout = 1,
@@ -129,3 +130,9 @@ By default the notification has a 1 second timeout that can be changed with `not
 
 Furthermore, you can customize the notification messages with `notify.message`.
 For the `new` and `delete` messages, the `<key>` and `<folder>` keywords can be used, which will be replaced by the respective new/deleted bookmark's associated key and folder.
+
+### `custom_desc_input`
+
+When enabled, user can change description for new bookmark before it is saved.
+
+By default the custom description input is filled with path.

--- a/main.lua
+++ b/main.lua
@@ -118,11 +118,15 @@ local _save_last_directory = ya.sync(function(state, persist)
 	end)
 end)
 
+local _is_custom_desc_input_enabled = ya.sync(function(state, persist)
+	return state.custom_desc_input
+end)
+
 -- ***********************************************
 -- **============= C O M M A N D S =============**
 -- ***********************************************
 
-local save_bookmark = ya.sync(function(state, idx)
+local save_bookmark = ya.sync(function(state, idx, custom_desc)
 	local file = _get_bookmark_file()
 
 	state.bookmarks = state.bookmarks or {}
@@ -131,10 +135,15 @@ local save_bookmark = ya.sync(function(state, idx)
 	if not _idx then
 		_idx = #state.bookmarks + 1
 	end
+	
+	local bookmark_desc = tostring(file.url)
+	if custom_desc then
+		bookmark_desc = tostring(custom_desc)
+	end
 
 	state.bookmarks[_idx] = {
 		on = SUPPORTED_KEYS[idx].on,
-		desc = _generate_description(file),
+		desc = bookmark_desc,
 		path = tostring(file.url),
 		is_parent = file.is_parent,
 	}
@@ -226,6 +235,21 @@ return {
 		if action == "save" then
 			local key = ya.which { cands = SUPPORTED_KEYS, silent = true }
 			if key then
+				if _is_custom_desc_input_enabled() then
+					local file = _get_bookmark_file()
+					local value, event = ya.input {
+						title = "Save with custom description:",
+						position = { "top-center", y = 3, w = 60 },
+						value = tostring(file.url) 
+					}
+					if event ~= 1 then
+						return
+					end
+
+					save_bookmark(key, value)
+					return
+				end
+
 				save_bookmark(key)
 			end
 			return
@@ -277,6 +301,10 @@ return {
 			state.file_pick_mode = "parent"
 		else
 			state.file_pick_mode = "hover"
+		end
+
+		if type(args.custom_desc_input) == "boolean" then
+			state.custom_desc_input = args.custom_desc_input
 		end
 
 		state.notify = {

--- a/main.lua
+++ b/main.lua
@@ -118,9 +118,7 @@ local _save_last_directory = ya.sync(function(state, persist)
 	end)
 end)
 
-local _is_custom_desc_input_enabled = ya.sync(function(state, persist)
-	return state.custom_desc_input
-end)
+local _is_custom_desc_input_enabled = ya.sync(function(state) return state.custom_desc_input end)
 
 -- ***********************************************
 -- **============= C O M M A N D S =============**
@@ -135,7 +133,7 @@ local save_bookmark = ya.sync(function(state, idx, custom_desc)
 	if not _idx then
 		_idx = #state.bookmarks + 1
 	end
-	
+
 	local bookmark_desc = tostring(file.url)
 	if custom_desc then
 		bookmark_desc = tostring(custom_desc)
@@ -236,11 +234,10 @@ return {
 			local key = ya.which { cands = SUPPORTED_KEYS, silent = true }
 			if key then
 				if _is_custom_desc_input_enabled() then
-					local file = _get_bookmark_file()
 					local value, event = ya.input {
 						title = "Save with custom description:",
 						position = { "top-center", y = 3, w = 60 },
-						value = tostring(file.url) 
+						value = tostring(_get_bookmark_file().url),
 					}
 					if event ~= 1 then
 						return
@@ -249,7 +246,6 @@ return {
 					save_bookmark(key, value)
 					return
 				end
-
 				save_bookmark(key)
 			end
 			return


### PR DESCRIPTION
I use this plugin daily and its super.
But as bookmark count increases it is little bit messy when '.
I know i can customize bookmark descriptions in .dds file, but it is not user friendly.

So i decided to create a config option that will bring input window when new bookmark is being created and user can customize description that is saved.


https://github.com/user-attachments/assets/c1ff3133-b0fd-4c29-8853-97e93ebd5374


