### PR TITLE
Make desk_format apply when creating new bookmarks

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -155,7 +155,7 @@ local save_bookmark = ya.sync(function(state, idx, custom_desc)
 		_idx = #state.bookmarks + 1
 	end
 
-	local bookmark_desc = tostring(file.url)
+	local bookmark_desc = tostring(_generate_description(file))
 	if custom_desc then
 		bookmark_desc = tostring(custom_desc)
 	end


### PR DESCRIPTION
fixes: https://github.com/dedukun/bookmarks.yazi/issues/45

If a user may choose to set multiple marks in the same parent dir for various hovered items, this won't look good. They would be better off setting desc_format = "full".

This is however closer to Ranger marks and will look clean for those who only set one mark per directory.