### PR TITLE
fix: replace deprecated ya.mgr_emit() with ya.emit()

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -310,9 +310,9 @@ return {
 			end
 
 			if bookmarks[selected].is_parent then
-				ya.mgr_emit("cd", { bookmarks[selected].path })
+				ya.emit("cd", { bookmarks[selected].path })
 			else
-				ya.mgr_emit("reveal", { bookmarks[selected].path })
+				ya.emit("reveal", { bookmarks[selected].path })
 			end
 		elseif action == "delete" then
 			delete_bookmark(selected)


### PR DESCRIPTION
 has been deprecated since yazi v25.5.28 and will soon be removed.

This PR replaces both occurrences with , which is the direct replacement — without a component prefix it defaults to `[manager]`, same behavior as `ya.mgr_emit()`.

See: https://github.com/sxyazi/yazi/pull/2653